### PR TITLE
Route based on encoded URL path

### DIFF
--- a/servemux.go
+++ b/servemux.go
@@ -52,9 +52,9 @@ func (s *ServeMux) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	// check if we have a host specific route tree to consult
 	hostRoute, ok := s.hostRoutes[req.URL.Host]
 	if ok {
-		ex = hostRoute.execute(req.Method, req.URL.Path)
+		ex = hostRoute.execute(req.Method, req.URL.EscapedPath())
 	} else {
-		ex = s.baseRoute.execute(req.Method, req.URL.Path)
+		ex = s.baseRoute.execute(req.Method, req.URL.EscapedPath())
 	}
 
 	// If there is no handler, run the not found handler
@@ -124,9 +124,9 @@ func (s *ServeMux) HandlerAndMiddleware(r *http.Request) (http.Handler, []Middle
 	// Get the route execution
 	var ex *routeExecution
 	if route, ok := s.hostRoutes[r.URL.Host]; ok {
-		ex = route.execute(r.Method, r.URL.Path)
+		ex = route.execute(r.Method, r.URL.EscapedPath())
 	} else {
-		ex = s.baseRoute.execute(r.Method, r.URL.Path)
+		ex = s.baseRoute.execute(r.Method, r.URL.EscapedPath())
 	}
 
 	// reconstruct the path

--- a/servemux_test.go
+++ b/servemux_test.go
@@ -34,7 +34,7 @@ func TestServeMux_ParamPrecedence(t *testing.T) {
 	}
 
 	if path != "/users/jim/info" {
-		t.Error("Wrong path name")
+		t.Errorf("Wrong string path: %s", path)
 	}
 }
 
@@ -46,14 +46,14 @@ func TestServeMux_WildcardPrecedence(t *testing.T) {
 	s.Route("/users/john").Get(rightHandler)
 
 	req := httptest.NewRequest(http.MethodGet, "/users/john", nil)
-	h, str := s.Handler(req)
+	h, path := s.Handler(req)
 
 	if h != rightHandler {
 		t.Error("Wrong handler returned")
 	}
 
-	if str != "/users/john" {
-		t.Error("Wrong path name")
+	if path != "/users/john" {
+		t.Errorf("Wrong string path: %s", path)
 	}
 }
 
@@ -120,7 +120,7 @@ func TestServeMux_HandleCorrectRoute(t *testing.T) {
 	}
 
 	if path != "/a" {
-		t.Error("Wrong string path")
+		t.Errorf("Wrong string path: %s", path)
 	}
 }
 
@@ -140,7 +140,7 @@ func TestServeMux_HandleCorrectRouteAfterParam(t *testing.T) {
 	}
 
 	if path != "/base/:id/a" {
-		t.Error("Wrong string path")
+		t.Errorf("Wrong string path: %s", path)
 	}
 }
 
@@ -160,7 +160,7 @@ func TestServeMux_HandleCorrectMethod(t *testing.T) {
 	}
 
 	if path != "/a" {
-		t.Error("Wrong string path")
+		t.Errorf("Wrong string path: %s", path)
 	}
 }
 
@@ -181,7 +181,7 @@ func TestServeMux_HandleCorrectMethodAny(t *testing.T) {
 	}
 
 	if path != "/a" {
-		t.Error("Wrong string path")
+		t.Errorf("Wrong string path: %s", path)
 	}
 }
 
@@ -201,7 +201,7 @@ func TestServeMux_HandleCorrectMethodHead(t *testing.T) {
 	}
 
 	if path != "/a" {
-		t.Error("Wrong string path")
+		t.Errorf("Wrong string path: %s", path)
 	}
 }
 
@@ -221,7 +221,7 @@ func TestServeMux_HandleWildcard(t *testing.T) {
 	}
 
 	if path != "/a/*" {
-		t.Error("Wrong string path")
+		t.Errorf("Wrong string path: %s", path)
 	}
 }
 
@@ -241,7 +241,7 @@ func TestServeMux_HandleWildcardDepth(t *testing.T) {
 	}
 
 	if path != "/a/*" {
-		t.Error("Wrong string path")
+		t.Errorf("Wrong string path: %s", path)
 	}
 }
 
@@ -261,7 +261,7 @@ func TestServeMux_HandleOrder(t *testing.T) {
 	}
 
 	if path != "/b" {
-		t.Error("Wrong string path")
+		t.Errorf("Wrong string path: %s", path)
 	}
 }
 
@@ -280,6 +280,24 @@ func TestServeMux_HandleOptionsAtDepth(t *testing.T) {
 	}
 
 	if path != "/a/b" {
-		t.Error("Wrong string path")
+		t.Errorf("Wrong string path: %s", path)
+	}
+}
+
+// Ensure routing is not performed on decoded path components
+func TestServeMux_Encoded(t *testing.T) {
+	s := NewServeMux()
+
+	s.Route("/users/:id/info").Get(rightHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/users/ji%2Fm/info", nil)
+	h, path := s.Handler(req)
+
+	if h != rightHandler {
+		t.Error("Wrong handler returned")
+	}
+
+	if path != "/users/:id/info" {
+		t.Errorf("Wrong string path: %s", path)
 	}
 }


### PR DESCRIPTION
Routing should be based on the raw, encoded URL path. `URL.Path` contains the decoded path: https://golang.org/pkg/net/url/#URL 