### PR TITLE
Sorted children

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,4 @@
 language: go
+branches:
+  only:
+    - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: go
 branches:
   only:
-    - master
+  - master
+before_install:
+  - go get golang.org/x/tools/cmd/cover
+  - go get github.com/mattn/goveralls
+script:
+  - $HOME/gopath/bin/goveralls -service=travis-ci
+  - go test -benchmem -bench .
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # PowerMux
-[![Build Status](https://travis-ci.org/AndrewBurian/powermux.svg?branch=master)](https://travis-ci.org/AndrewBurian/powermux)  
+[![Build Status](https://travis-ci.org/AndrewBurian/powermux.svg?branch=master)](https://travis-ci.org/AndrewBurian/powermux)
+[![Coverage Status](https://coveralls.io/repos/github/AndrewBurian/powermux/badge.svg?branch=master)](https://coveralls.io/github/AndrewBurian/powermux?branch=master)
+
+
 A drop-in replacement for Go's `http.ServeMux` with all the missing features
 
 PowerMux stores routes in Radix trees for fast route matching and lookup on large numbers of routes.

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,89 @@
+package powermux
+
+import (
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const (
+	MAX_WIDTH  = 500
+	MAX_DEPTH  = 100
+	FAN_DEPTH  = 4
+	FAN_SPREAD = 8
+)
+
+func BenchmarkSingleRoute(b *testing.B) {
+	r := NewServeMux()
+	r.Route("/").Any(rightHandler)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		r.Handler(req)
+	}
+}
+
+func BenchmarkShallowAndWide(b *testing.B) {
+	r := NewServeMux()
+	requests := make([]*http.Request, 0, MAX_WIDTH)
+	for i := 0; i < MAX_WIDTH; i++ {
+		route := "/" + hex.EncodeToString([]byte(fmt.Sprint(i)))
+		r.Handle(route, rightHandler)
+		requests = append(requests, httptest.NewRequest(http.MethodGet, route, nil))
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		r.Handler(requests[i%MAX_WIDTH])
+	}
+}
+
+// BenchmarkNarrowAndDeep is powermux's worst-case scenario. One route at the end
+// of a really long path
+func BenchmarkNarrowAndDeep(b *testing.B) {
+	r := NewServeMux()
+	var route string
+	for i := 0; i < MAX_DEPTH; i++ {
+		route += "/" + hex.EncodeToString([]byte(fmt.Sprint(i)))
+	}
+	r.Handle(route, rightHandler)
+	req := httptest.NewRequest(http.MethodGet, route, nil)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		r.Handler(req)
+	}
+}
+
+func addFanRoutes(n int, r *Route) (routes []string) {
+	for i := 0; i < FAN_SPREAD; i++ {
+		route := "/" + hex.EncodeToString([]byte(fmt.Sprint(i)))
+		r2 := r.Route(route)
+		routes = append(routes, route)
+		if n == 0 {
+			break
+		}
+		addedRoutes := addFanRoutes(n-1, r2)
+		routes = append(routes, addedRoutes...)
+	}
+
+	return routes
+}
+
+func BenchmarkFan(b *testing.B) {
+	r := NewServeMux()
+	routes := addFanRoutes(FAN_DEPTH, r.Route("/"))
+	requests := make([]*http.Request, 0, len(routes))
+	for _, route := range routes {
+		req := httptest.NewRequest(http.MethodGet, route, nil)
+		requests = append(requests, req)
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		r.Handler(requests[i%len(requests)])
+	}
+}

--- a/bench_test.go
+++ b/bench_test.go
@@ -61,7 +61,7 @@ func BenchmarkNarrowAndDeep(b *testing.B) {
 func addFanRoutes(n int, r *Route) (routes []string) {
 	for i := 0; i < FAN_SPREAD; i++ {
 		route := "/" + hex.EncodeToString([]byte(fmt.Sprint(i)))
-		r2 := r.Route(route)
+		r2 := r.Route(route).Any(rightHandler)
 		routes = append(routes, route)
 		if n == 0 {
 			break


### PR DESCRIPTION
To improve the performance of wide and flat route trees, child nodes are now sorted at define time, and then binary searched over.

Closes #13 