### PR TITLE
Added RequestPath function

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,23 @@ If multiple routes are declared that could match a given path, they are selected
   2. A path with parameters `/users/:id/info`
   3. A wildcard path `/users/*`
 
+## Retrieving the original route path
+
+Handlers and Middleware may access the route pattern that was used by powermux to route any particular 
+request with the `RequestPath` function.
+
+```go
+servemux.Route("/users/:id/info").Get(userHandler)
+...
+// envoked with /users/andrew/info
+func ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+        originalPath := powermux.RequestPath(req)
+        
+        originalPath == "/users/:id/info"
+        req.URL.Path == "/users/andrew/info"
+}
+```
+
 ## Handler precedence
 
 When multiple handlers are declared on a single route for different methods, they are selected in this order:

--- a/servemux_test.go
+++ b/servemux_test.go
@@ -18,8 +18,8 @@ func (h dummyHandler) ServeHTTPMiddleware(w http.ResponseWriter, r *http.Request
 	n(w, r)
 }
 
-func dummyHandlerFunc(response string) func (w http.ResponseWriter, r *http.Request) {
-	return func (w http.ResponseWriter, r *http.Request) {
+func dummyHandlerFunc(response string) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, response)
 	}
 }
@@ -629,5 +629,23 @@ func TestServeMux_MiddlewareFunc(t *testing.T) {
 
 	if !called {
 		t.Error("Middleware not called")
+	}
+}
+
+func TestServeMux_RequestPath(t *testing.T) {
+	s := NewServeMux()
+
+	var reqPath string
+
+	s.Route("/users/:id/info").GetFunc(func(res http.ResponseWriter, req *http.Request) {
+		reqPath = RequestPath(req)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/users/andrew/info", nil)
+
+	s.ServeHTTP(nil, req)
+
+	if reqPath != "/users/:id/info" {
+		t.Error("Wrong request path returned", reqPath)
 	}
 }


### PR DESCRIPTION
Allows middleware and handlers access to the raw route definition path

Also fixes a bug where multiple path parameters wouldn't be saved.