### PR TITLE
Switched individual context entries for a map

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,10 @@ before_install:
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/mattn/goveralls
 script:
-  - $HOME/gopath/bin/goveralls -service=travis-ci
+  #- $HOME/gopath/bin/goveralls -service=travis-ci
+  - go test -coverprofile=coverage.txt
   - go test -benchmem -bench .
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ branches:
   - master
 before_install:
   - go get golang.org/x/tools/cmd/cover
-  - go get github.com/mattn/goveralls
 script:
-  #- $HOME/gopath/bin/goveralls -service=travis-ci
   - go test -coverprofile=coverage.txt
   - go test -benchmem -bench .
 after_success:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # PowerMux
 
 [![Build Status](https://travis-ci.org/AndrewBurian/powermux.svg?branch=master)](https://travis-ci.org/AndrewBurian/powermux)
-[![Coverage Status](https://coveralls.io/repos/github/AndrewBurian/powermux/badge.svg?branch=master)](https://coveralls.io/github/AndrewBurian/powermux?branch=master)
+[![codecov](https://codecov.io/gh/AndrewBurian/powermux/branch/master/graph/badge.svg)](https://codecov.io/gh/AndrewBurian/powermux)
+
 
 A drop-in replacement for Go's `http.ServeMux` with all the missing features
 

--- a/servemux.go
+++ b/servemux.go
@@ -32,9 +32,13 @@ func PathParam(req *http.Request, name string) (value string) {
 
 // PathParams returns the map of all path parameters and their values from the request.
 //
-// Altering the values of this map will affect future calls to PathParam and PathParams for this request.
-func PathParams(req *http.Request) map[string]string {
-	return req.Context().Value(paramKey).(map[string]string)
+// Altering the values of this map will not affect future calls to PathParam and PathParams.
+func PathParams(req *http.Request) (params map[string]string) {
+	params = make(map[string]string)
+	for k, v := range req.Context().Value(paramKey).(map[string]string) {
+		params[k] = v
+	}
+	return
 }
 
 // RequestPath returns the path definition that the router used to serve this request,

--- a/servemux.go
+++ b/servemux.go
@@ -16,19 +16,25 @@ type ServeMux struct {
 // ctxKey is the key type used for path parameters in the request context
 type ctxKey string
 
-// ctxRouteNameKey is the type used for the route in the request context.
-// Distinct from ctxKey to avoid collisions
-type ctxRouteNameKey string
-
-var routeKey = ctxRouteNameKey("route_name")
+var (
+	routeKey = ctxKey("route_name")
+	paramKey = ctxKey("params")
+)
 
 // PathParam gets named path parameters and their values from the request
 //
 // the path '/users/:name' given '/users/andrew' will have `PathParam(r, "name")` => `"andrew"`
 // unset values return an empty stringRoutes
 func PathParam(req *http.Request, name string) (value string) {
-	value, _ = req.Context().Value(ctxKey(name)).(string)
+	value = req.Context().Value(paramKey).(map[string]string)[name]
 	return
+}
+
+// PathParams returns the map of all path parameters and their values from the request.
+//
+// Altering the values of this map will affect future calls to PathParam and PathParams for this request.
+func PathParams(req *http.Request) map[string]string {
+	return req.Context().Value(paramKey).(map[string]string)
 }
 
 // RequestPath returns the path definition that the router used to serve this request,
@@ -79,11 +85,7 @@ func (s *ServeMux) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	ctx := context.WithValue(req.Context(), routeKey, ex.pattern)
 
 	// set all the path params
-	if len(ex.params) > 0 {
-		for key, val := range ex.params {
-			ctx = context.WithValue(ctx, ctxKey(key), val)
-		}
-	}
+	ctx = context.WithValue(ctx, paramKey, ex.params)
 
 	// Save context into request
 	req = req.WithContext(ctx)

--- a/servemux_test.go
+++ b/servemux_test.go
@@ -649,3 +649,35 @@ func TestServeMux_RequestPath(t *testing.T) {
 		t.Error("Wrong request path returned", reqPath)
 	}
 }
+
+func TestPathParams(t *testing.T) {
+	s := NewServeMux()
+
+	var params map[string]string
+
+	handler := func(res http.ResponseWriter, r *http.Request) {
+		params = PathParams(r)
+	}
+
+	s.Route("/:a/:b/:c/").GetFunc(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/andrew/a/burian", nil)
+
+	s.ServeHTTP(nil, req)
+
+	if len(params) != 3 {
+		t.Error("Wrong number of params returned", len(params))
+	}
+
+	if params["a"] != "andrew" {
+		t.Error("Wrong value for a,", params["a"])
+	}
+
+	if params["b"] != "a" {
+		t.Error("Wrong value for b,", params["b"])
+	}
+
+	if params["c"] != "burian" {
+		t.Error("Wrong value for c,", params["c"])
+	}
+}


### PR DESCRIPTION
Far more efficient to retrieve the map then lookup on the map than it
is to try to pull lots of single values out of the context.

Far far faster to store multiple values into the context.

Also enables the get-all `PathParams()` function