### PR TITLE
Polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,17 @@ mux.Route("/c").Middleware(midC)
 // then any handlers on Route("/a/b")
 ```
 
+## Host specific routes
+
+Unlike the Go default multiplexer, host specific routes need to be handled separately. Use the `*Host` varients of
+common functions to achieve this.
+```go
+mux.Route("/test")
+mux.RouteHost("example.com", "/text")
+
+// request to any host other than example.com will go to the first handler
+```
+
 ## Not Found and OPTIONS handlers
 
 `Options` and `NotFound` handlers are treated specially. If one is not found on the Route node requested, 

--- a/README.md
+++ b/README.md
@@ -189,5 +189,4 @@ When multiple handlers are declared on a single route for different methods, the
   1. An exact method match
   2. HEAD requests can use GET handlers
   3. The ANY handler
-  4. A generated Options handler if this is an options request and no previous options handler is set above this route
-  5. A generated Method Not Allowed handler
+  4. A generated Method Not Allowed handler

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ mux.Route("/c").Middleware(midC)
 
 ## Host specific routes
 
-Unlike the Go default multiplexer, host specific routes need to be handled separately. Use the `*Host` varients of
+Unlike the Go default multiplexer, host specific routes need to be handled separately. Use the `*Host` variants of
 common functions to achieve this.
 ```go
 mux.Route("/test")

--- a/handlers.go
+++ b/handlers.go
@@ -51,9 +51,3 @@ func (r *Route) methodNotAllowed() http.Handler {
 
 	return nil
 }
-
-// defaultOptions generates an options handler for this route
-func (r *Route) defaultOptions() http.Handler {
-	//todo not even sure if this is actually a good idea
-	return nil
-}

--- a/route.go
+++ b/route.go
@@ -207,12 +207,6 @@ func (r *Route) getHandler(method string, ex *routeExecution) {
 		return
 	}
 
-	// generate an options handler if none is already set
-	if method == http.MethodOptions && ex.handler == nil {
-		ex.handler = r.defaultOptions()
-		return
-	}
-
 	// last ditch effort is to generate our own method not allowed handler
 	// this is regenerated each time in case routes are added during runtime
 	// not generated if a previous handler is already set

--- a/route.go
+++ b/route.go
@@ -131,11 +131,9 @@ func (r *Route) getExecution(method string, pathParts []string, ex *routeExecuti
 
 		// save path parameters
 		if curRoute.isParam {
-			value, err := url.PathUnescape(pathParts[0])
-			if err != nil {
-				// TODO: maybe handle errors more gracefully
-				panic(err)
-			}
+			// Errors here will never happen as Go's http server sanitizes inputs before
+			// they are handled by the mux, therefore the error return is ignored
+			value, _ := url.PathUnescape(pathParts[0])
 			ex.params[curRoute.paramName] = value
 		}
 

--- a/route_test.go
+++ b/route_test.go
@@ -234,3 +234,39 @@ func TestRoute_MethodHandlerFuncs(t *testing.T) {
 		}
 	}
 }
+
+func TestRoute_AnyFunc(t *testing.T) {
+	s := NewServeMux()
+	r := s.Route("/")
+
+	rightFunc := dummyHandlerFunc("any")
+
+	r.AnyFunc(rightFunc)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	s.ServeHTTP(rec, req)
+
+	if rec.Body.String() != "any" {
+		t.Error("Body doesn't match")
+	}
+}
+
+func TestRoute_NotFoundFunc(t *testing.T) {
+	s := NewServeMux()
+	r := s.Route("/")
+
+	rightFunc := dummyHandlerFunc("notFound")
+
+	r.NotFoundFunc(rightFunc)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	s.ServeHTTP(rec, req)
+
+	if rec.Body.String() != "notFound" {
+		t.Error("Body doesn't match")
+	}
+}

--- a/servemux.go
+++ b/servemux.go
@@ -108,7 +108,7 @@ func (s *ServeMux) Handle(path string, handler http.Handler) {
 // HandleHost registers the handler for the given pattern and host.
 // If a handler already exists for pattern it is overwritten.
 func (s *ServeMux) HandleHost(host, path string, handler http.Handler) {
-	s.RouteHost(path, host).Any(handler)
+	s.RouteHost(host, path).Any(handler)
 }
 
 // Middleware adds middleware for the given pattern.

--- a/servemux.go
+++ b/servemux.go
@@ -155,7 +155,7 @@ func (s *ServeMux) HandlerAndMiddleware(r *http.Request) (http.Handler, []Middle
 	if path != "/" && strings.HasSuffix(path, "/") {
 		r.URL.Path = strings.TrimRight(path, "/")
 		redirect := http.RedirectHandler(r.URL.RequestURI(), http.StatusPermanentRedirect)
-		return redirect, make([]Middleware,0), r.URL.EscapedPath()
+		return redirect, make([]Middleware, 0), r.URL.EscapedPath()
 	}
 
 	// Get the route execution
@@ -196,13 +196,21 @@ func (s *ServeMux) NotFound(handler http.Handler) {
 
 // String returns a list of all routes registered with this server
 func (s *ServeMux) String() string {
-	routes := make([]string, 0)
+	routes := make([]string, 0, 1)
 	s.baseRoute.stringRoutes(&routes)
 
 	buf := bytes.Buffer{}
 
 	for _, route := range routes {
 		buf.WriteString(route + "\n")
+	}
+
+	for host, baseRoute := range s.hostRoutes {
+		routes = routes[0:0]
+		baseRoute.stringRoutes(&routes)
+		for _, route := range routes {
+			buf.WriteString(host + route + "\n")
+		}
 	}
 
 	return buf.String()

--- a/servemux.go
+++ b/servemux.go
@@ -149,6 +149,15 @@ func (s *ServeMux) Handler(r *http.Request) (http.Handler, string) {
 // they would have been executed
 func (s *ServeMux) HandlerAndMiddleware(r *http.Request) (http.Handler, []Middleware, string) {
 
+	path := r.URL.EscapedPath()
+
+	// Check for redirect
+	if path != "/" && strings.HasSuffix(path, "/") {
+		r.URL.Path = strings.TrimRight(path, "/")
+		redirect := http.RedirectHandler(r.URL.RequestURI(), http.StatusPermanentRedirect)
+		return redirect, make([]Middleware,0), r.URL.EscapedPath()
+	}
+
 	// Get the route execution
 	var ex *routeExecution
 	if route, ok := s.hostRoutes[r.URL.Host]; ok {

--- a/servemux_test.go
+++ b/servemux_test.go
@@ -681,3 +681,22 @@ func TestPathParams(t *testing.T) {
 		t.Error("Wrong value for c,", params["c"])
 	}
 }
+
+func TestPathParamsImmutable(t *testing.T) {
+	s := NewServeMux()
+
+	handler := func(res http.ResponseWriter, r *http.Request) {
+		params := PathParams(r)
+		params["id"] = "wrong"
+		params = PathParams(r)
+		if params["id"] == "wrong" {
+			t.Error("Path params aren't immutable")
+		}
+	}
+
+	s.Route("/:id/").GetFunc(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/andrew", nil)
+
+	s.ServeHTTP(nil, req)
+}

--- a/servemux_test.go
+++ b/servemux_test.go
@@ -799,3 +799,64 @@ func TestServeMux_NotFoundDepth(t *testing.T) {
 		t.Error("Wrong path returned", path)
 	}
 }
+
+func TestServeMux_RouteHost(t *testing.T) {
+	s := NewServeMux()
+
+	s.RouteHost("example.com", "/").Get(rightHandler)
+	s.Route("/").Get(wrongHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.URL.Host = "example.com"
+
+	h, path := s.Handler(req)
+
+	if h != rightHandler {
+		t.Error("Wrong handler returned")
+	}
+	if path != "/" {
+		t.Error("Wrong path set")
+	}
+}
+
+func TestServeMux_HandleHost(t *testing.T) {
+	s := NewServeMux()
+
+	s.HandleHost("example.com", "/", rightHandler)
+	s.Handle("/", wrongHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.URL.Host = "example.com"
+
+	h, path := s.Handler(req)
+
+	if h != rightHandler {
+		t.Error("Wrong handler returned")
+	}
+	if path != "/" {
+		t.Error("Wrong path set")
+	}
+}
+
+func TestServeMux_MiddlewareHost(t *testing.T) {
+	s := NewServeMux()
+
+	s.MiddlewareHost("example.com", "/", mid1)
+	s.HandleHost("example.com", "/", rightHandler)
+
+	s.Middleware("/", mid2)
+	s.Handle("/", wrongHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.URL.Host = "example.com"
+
+	_, mids, _ := s.HandlerAndMiddleware(req)
+
+	if len(mids) != 1 {
+		t.Fatal("Wrong number of middlewares returned. Expected 1, got", len(mids))
+	}
+
+	if mids[0] != mid1 {
+		t.Error("wat")
+	}
+}

--- a/servemux_test.go
+++ b/servemux_test.go
@@ -773,3 +773,22 @@ func TestServeMux_NotFound(t *testing.T) {
 		t.Error("Wrong path returned", path)
 	}
 }
+
+func TestServeMux_NotFoundDepth(t *testing.T) {
+	s := NewServeMux()
+	s.NotFound(wrongHandler)
+	s.Route("/get").NotFound(rightHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/get/llama", nil)
+
+	h, path := s.Handler(req)
+
+	if h != rightHandler {
+		t.Error("Wrong not found handler returned")
+	}
+
+	// not found should return an empty pattern
+	if path != "" {
+		t.Error("Wrong path returned", path)
+	}
+}

--- a/servemux_test.go
+++ b/servemux_test.go
@@ -165,6 +165,19 @@ func TestServeMux_RedirectSlash(t *testing.T) {
 	}
 }
 
+// Ensures trailing slash redirects are working and return the redirect path
+func TestServeMux_RedirectSlashPath(t *testing.T) {
+	s := NewServeMux()
+
+	req := httptest.NewRequest(http.MethodGet, "/users/", nil)
+
+	_, path := s.Handler(req)
+
+	if path != "/users" {
+		t.Error("Path not corrected")
+	}
+}
+
 // Ensures we don't redirect the root
 func TestServeMux_RedirectRoot(t *testing.T) {
 	s := NewServeMux()
@@ -741,4 +754,22 @@ func TestServeMux_String(t *testing.T) {
 		t.Error("Root route not included", containsStr(routes, "/"))
 	}
 
+}
+
+func TestServeMux_NotFound(t *testing.T) {
+	s := NewServeMux()
+	s.NotFound(rightHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/llama", nil)
+
+	h, path := s.Handler(req)
+
+	if h != rightHandler {
+		t.Error("Wrong not found handler returned")
+	}
+
+	// not found should return an empty pattern
+	if path != "" {
+		t.Error("Wrong path returned", path)
+	}
 }

--- a/servemux_test.go
+++ b/servemux_test.go
@@ -860,3 +860,35 @@ func TestServeMux_MiddlewareHost(t *testing.T) {
 		t.Error("wat")
 	}
 }
+
+func TestServeMux_HandleFunc(t *testing.T) {
+	s := NewServeMux()
+
+	rightFunc := dummyHandlerFunc("handlefunc")
+	s.HandleFunc("/", rightFunc)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	s.ServeHTTP(rec, req)
+
+	if rec.Body.String() != "handlefunc" {
+		t.Error("Body doesn't match")
+	}
+}
+
+func TestServeMux_ServeHTTPHost(t *testing.T) {
+	s := NewServeMux()
+
+	s.RouteHost("example.com", "/").Get(rightHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.URL.Host = "example.com"
+	rec := httptest.NewRecorder()
+
+	s.ServeHTTP(rec, req)
+
+	if rec.Body.String() != "right" {
+		t.Error("Wrong handler executed")
+	}
+}

--- a/servemux_test.go
+++ b/servemux_test.go
@@ -734,13 +734,15 @@ func TestServeMux_String(t *testing.T) {
 
 	s.Route("/multi").Get(rightHandler).Post(rightHandler)
 
+	s.RouteHost("example.com", "/another").Any(rightHandler)
+
 	str := strings.Trim(s.String(), "\n")
 	routes := strings.Split(str, "\n")
 
 	t.Logf("String:\n%s", str)
 
 	// right number of statements
-	if len(routes) != 3 {
+	if len(routes) != 4 {
 		t.Error("Wrong number of routes returned", len(routes))
 	}
 
@@ -752,6 +754,11 @@ func TestServeMux_String(t *testing.T) {
 	// root handler included properly
 	if containsStr(routes, "/") != 0 {
 		t.Error("Root route not included", containsStr(routes, "/"))
+	}
+
+	// host route included properly
+	if containsStr(routes, "example.com/another") == 0 {
+		t.Error("Did not inlcude host specific route")
 	}
 
 }


### PR DESCRIPTION
Bit of a grab-bag of a PR. Lots of little fixes towards a 1.0 release.

- Removed the generated options handler, wasn't a good idea
- Serve mux's `String` now includes routes for specific hosts
- Fixed a bug in the `HandleHost` function where parameters were reversed
- Fixed `Handler` logic for when a redirect is returned
- Lots of additional tests