### PR TITLE
Benchmarks now use ServeHTTP instead of Handler

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -95,3 +95,16 @@ func BenchmarkFan(b *testing.B) {
 		r.ServeHTTP(nil, requests[i%len(requests)])
 	}
 }
+
+func BenchmarkSingleRouteParallel(b *testing.B) {
+	r := NewServeMux()
+	r.Route("/").Any(emptyHandle)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			r.ServeHTTP(nil, req)
+		}
+	})
+}

--- a/bench_test.go
+++ b/bench_test.go
@@ -15,14 +15,22 @@ const (
 	FAN_SPREAD = 8
 )
 
+type noopHandler struct{}
+
+func (h *noopHandler) ServeHTTP(_ http.ResponseWriter, _ *http.Request) {
+	//noop
+}
+
+var emptyHandle = &noopHandler{}
+
 func BenchmarkSingleRoute(b *testing.B) {
 	r := NewServeMux()
-	r.Route("/").Any(rightHandler)
+	r.Route("/").Any(emptyHandle)
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		r.Handler(req)
+		r.ServeHTTP(nil, req)
 	}
 }
 
@@ -31,13 +39,13 @@ func BenchmarkShallowAndWide(b *testing.B) {
 	requests := make([]*http.Request, 0, MAX_WIDTH)
 	for i := 0; i < MAX_WIDTH; i++ {
 		route := "/" + hex.EncodeToString([]byte(fmt.Sprint(i)))
-		r.Handle(route, rightHandler)
+		r.Handle(route, emptyHandle)
 		requests = append(requests, httptest.NewRequest(http.MethodGet, route, nil))
 	}
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		r.Handler(requests[i%MAX_WIDTH])
+		r.ServeHTTP(nil, requests[i%MAX_WIDTH])
 	}
 }
 
@@ -49,19 +57,19 @@ func BenchmarkNarrowAndDeep(b *testing.B) {
 	for i := 0; i < MAX_DEPTH; i++ {
 		route += "/" + hex.EncodeToString([]byte(fmt.Sprint(i)))
 	}
-	r.Handle(route, rightHandler)
+	r.Handle(route, emptyHandle)
 	req := httptest.NewRequest(http.MethodGet, route, nil)
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		r.Handler(req)
+		r.ServeHTTP(nil, req)
 	}
 }
 
 func addFanRoutes(n int, r *Route) (routes []string) {
 	for i := 0; i < FAN_SPREAD; i++ {
 		route := "/" + hex.EncodeToString([]byte(fmt.Sprint(i)))
-		r2 := r.Route(route).Any(rightHandler)
+		r2 := r.Route(route).Any(emptyHandle)
 		routes = append(routes, route)
 		if n == 0 {
 			break
@@ -84,6 +92,6 @@ func BenchmarkFan(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		r.Handler(requests[i%len(requests)])
+		r.ServeHTTP(nil, requests[i%len(requests)])
 	}
 }


### PR DESCRIPTION
cc @AndrewBurian 