### PR TITLE
Example & function signature

### DIFF
--- a/example/logger_middleware.go
+++ b/example/logger_middleware.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"github.com/Sirupsen/logrus"
+	"github.com/twinj/uuid"
+	"net/http"
+)
+
+// LoggerMiddleware is designed to act like a powermux compatible library
+//
+// It exposes an object that can be instantiated with any static properties needed to operate,
+// then the object can be registered as a middleware to inject data into the request context.
+//
+// It then exposes helper functions used for interacting with requests that have passed through its middleware.
+type LoggerMiddleware struct {
+	// the parent event common to all requests
+	baseEntry *logrus.Entry
+}
+
+// Middleware libraries should always use their own context key type to prevent context key collisions between
+// different middlewares
+type logCtxKeyType string
+
+var logCtxKey = logCtxKeyType("event")
+
+// Injects a new log entry with a request UUID into the request context
+func (m *LoggerMiddleware) ServeHTTPMiddleware(rw http.ResponseWriter, req *http.Request, next func(rw http.ResponseWriter, req *http.Request)) {
+
+	// inject the log into the context along with some info
+	entry := m.baseEntry.WithField("id", uuid.NewV4())
+
+	req = req.WithContext(context.WithValue(req.Context(), logCtxKey, entry))
+
+	next(rw, req)
+}
+
+// Gets the data out of the request context for use
+func getLogEntry(req *http.Request) *logrus.Entry {
+	return req.Context().Value(logCtxKey).(*logrus.Entry)
+}

--- a/example/main.go
+++ b/example/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/andrewburian/powermux"
+	"gopkg.in/pg.v5"
+	"net/http"
+)
+
+func main() {
+
+	// create the router
+	mux := powermux.NewServeMux()
+
+	// setup the logging helper
+	logger := &LoggerMiddleware{
+		baseEntry: logrus.NewEntry(logrus.StandardLogger()).WithField("project", "Powermux-sample"),
+	}
+
+	// add the logging middleware
+	mux.Route("/").Middleware(logger)
+
+	// set up static resources like the database
+	dbConnection := pg.Connect(&pg.Options{})
+
+	// create the static route handlers like this users handler
+	usersHandler := UserHandler{
+		db: dbConnection,
+	}
+
+	// Get the sub route
+	usersRoute := mux.Route("/users")
+
+	// let the handler add its own routes to the mux under the prefix we give it
+	usersHandler.Setup(usersRoute)
+
+	// create a handler object for static content
+	staticHandler := http.FileServer(http.Dir("/var/www/static"))
+
+	// register the whole object instead of bound functions
+	// as the fileServer implements the http.Handler interface
+	mux.Route("/static").Any(staticHandler)
+
+	// Serve
+	http.ListenAndServe(":8080", mux)
+}

--- a/example/user_handler.go
+++ b/example/user_handler.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"github.com/andrewburian/powermux"
+	"gopkg.in/pg.v5"
+	"net/http"
+)
+
+// UserHandler is a powermux handler. Any objects that can be statically shared between requests are kept
+// in the object itself, in this case the database pool.
+//
+// The handler doesn't implement the ServeHTTP interface, so instead individual functions need to be bound into
+// Powermux to route the requests. The UserHander does expose a Setup function where it does all this binding
+// to keep the logic in one place.
+type UserHandler struct {
+	db *pg.DB
+}
+
+// Sets up a user handler with all the required functions
+//
+// Note that this function takes a powermux Route, not the entire ServeMux. This is so that it can be agnostic
+// about the path leading up to it, but still have complete control over it's section of the route tree.
+func (h *UserHandler) Setup(r *powermux.Route) {
+
+	// using path parameters
+	// these functions don't know or care what the route is above them
+	r.Route("/:id").GetFunc(h.Get)
+
+	// use the root of this section of the route tree
+	r.PostFunc(h.CreateUser)
+}
+
+func (h *UserHandler) Get(rw http.ResponseWriter, req *http.Request) {
+	// use the static database connection from the handler
+	fmt.Println(h.db.String())
+
+	// get a path parameter
+	fmt.Println(powermux.PathParam(req, "id"))
+
+	// use the request-scoped log entry from the logging library middleware
+	entry := getLogEntry(req)
+	entry.WithField("function", "UserHandler.Get").Info("Did something!")
+}
+
+func (h *UserHandler) CreateUser(rw http.ResponseWriter, req *http.Request) {
+	// create the user
+	entry := getLogEntry(req)
+	entry.Info("User Created")
+}

--- a/middleware.go
+++ b/middleware.go
@@ -4,22 +4,19 @@ import (
 	"net/http"
 )
 
-// NextMiddlewareFunc is the function signature for the next parameter in ServerHTTPMiddleware
-type NextMiddlewareFunc func(http.ResponseWriter, *http.Request)
-
 //The MiddlewareFunc type is an adapter to allow the use of ordinary functions as HTTP middlewares.
 //
 // If f is a function with the appropriate signature, HandlerFunc(f) is a Handler that calls f.
-type MiddlewareFunc func(http.ResponseWriter, *http.Request, NextMiddlewareFunc)
+type MiddlewareFunc func(http.ResponseWriter, *http.Request, func(http.ResponseWriter, *http.Request))
 
 // ServeHTTPMiddleware calls f(w, r, n).
-func (m MiddlewareFunc) ServeHTTPMiddleware(rw http.ResponseWriter, req *http.Request, n NextMiddlewareFunc) {
+func (m MiddlewareFunc) ServeHTTPMiddleware(rw http.ResponseWriter, req *http.Request, n func(http.ResponseWriter, *http.Request)) {
 	m(rw, req, n)
 }
 
 // Middleware handles HTTP requests and optionally passes them along to the next handler in the chain.
 type Middleware interface {
-	ServeHTTPMiddleware(http.ResponseWriter, *http.Request, NextMiddlewareFunc)
+	ServeHTTPMiddleware(http.ResponseWriter, *http.Request, func(http.ResponseWriter, *http.Request))
 }
 
 // getNextMiddleware returns the first middleware of a recursive closure.

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -9,17 +9,17 @@ import (
 )
 
 func TestMiddleware_getNextMiddleware(t *testing.T) {
-	m1 := func(w http.ResponseWriter, r *http.Request, n NextMiddlewareFunc) {
+	m1 := func(w http.ResponseWriter, r *http.Request, n func(http.ResponseWriter, *http.Request)) {
 		io.WriteString(w, "middleware 1- ")
 		n(w, r)
 	}
 
-	m2 := func(w http.ResponseWriter, r *http.Request, n NextMiddlewareFunc) {
+	m2 := func(w http.ResponseWriter, r *http.Request, n func(http.ResponseWriter, *http.Request)) {
 		io.WriteString(w, "middleware 2- ")
 		n(w, r)
 	}
 
-	m3 := func(w http.ResponseWriter, r *http.Request, n NextMiddlewareFunc) {
+	m3 := func(w http.ResponseWriter, r *http.Request, n func(http.ResponseWriter, *http.Request)) {
 		n(w, r)
 		io.WriteString(w, "middleware 3- ")
 	}

--- a/servemux_test.go
+++ b/servemux_test.go
@@ -14,7 +14,7 @@ func (h dummyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	io.WriteString(w, string(h))
 }
 
-func (h dummyHandler) ServeHTTPMiddleware(w http.ResponseWriter, r *http.Request, n NextMiddlewareFunc) {
+func (h dummyHandler) ServeHTTPMiddleware(w http.ResponseWriter, r *http.Request, n func(http.ResponseWriter, *http.Request)) {
 	io.WriteString(w, string(h))
 	n(w, r)
 }
@@ -625,7 +625,7 @@ func TestServeMux_MiddlewareFunc(t *testing.T) {
 
 	var called bool
 
-	midFunc := func(res http.ResponseWriter, req *http.Request, next NextMiddlewareFunc) {
+	midFunc := func(res http.ResponseWriter, req *http.Request, next func(http.ResponseWriter, *http.Request)) {
 		called = true
 	}
 


### PR DESCRIPTION
Added an example for coding style reference.

Also fixed an issue so middleware no longer has to be powermux aware. The more generic function signature is accepted without having to cast.

@turbolent @Kay-Zee @chrisaxiom 