### PR TITLE
Added fix for zero-length segments (ie '//')

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/AndrewBurian/powermux
+
+go 1.14

--- a/handlers.go
+++ b/handlers.go
@@ -1,6 +1,7 @@
 package powermux
 
 import (
+	"io"
 	"net/http"
 	"strings"
 )
@@ -50,4 +51,16 @@ func (r *Route) methodNotAllowed() http.Handler {
 	}
 
 	return nil
+}
+
+type badRequestHandler string
+
+func (brh badRequestHandler) ServeHTTP(res http.ResponseWriter, _ *http.Request) {
+	res.Header().Set("Content-Type", "text/plain")
+	res.WriteHeader(http.StatusBadRequest)
+	io.WriteString(res, string(brh))
+}
+
+func (r *Route) badRequest(errMsg string) http.Handler{
+	return badRequestHandler(errMsg)
 }

--- a/routematrix_test.go
+++ b/routematrix_test.go
@@ -1,0 +1,73 @@
+package powermux
+
+import (
+	"fmt"
+	"testing"
+	"net/http"
+	"net/http/httptest"
+	"bytes"
+)
+
+type RouteTest struct {
+	route          string
+	body           string
+	method         string
+	expectCode     int
+	expectLocation string
+}
+
+var routeTests = []RouteTest{
+	{
+		route:      "/",
+		expectCode: http.StatusNotFound,
+	},
+	{
+		route:          "/foo/",
+		expectLocation: "/foo",
+	},
+	{
+		route:      "//example.com/",
+		expectCode: http.StatusBadRequest,
+	},
+	{
+		route:      "/foo//bar",
+		expectCode: http.StatusBadRequest,
+	},
+}
+
+func TestMuxRoutes(t *testing.T) {
+
+	mux := NewServeMux()
+	for _, tt := range routeTests {
+
+		// sane defaults
+		if tt.expectCode == 0 {
+			if tt.expectLocation != "" {
+				tt.expectCode = http.StatusPermanentRedirect
+			} else {
+				tt.expectCode = http.StatusOK
+			}
+		}
+		if tt.method == "" {
+			tt.method = http.MethodGet
+		}
+
+		t.Run(fmt.Sprintf("%s%s", tt.method, tt.route), func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(tt.method, tt.route, bytes.NewBufferString(tt.body))
+			mux.ServeHTTP(rec, req)
+
+			if rec.Code != tt.expectCode {
+				t.Fatalf("Unexpected status code, expected=%d actual=%d", tt.expectCode, rec.Code)
+			}
+
+			if tt.expectLocation != "" && (rec.Code / 100) != 3 {
+				t.Fatalf("Expected redirect, instead got code %d", rec.Code)
+			}
+
+			if tt.expectLocation != "" && tt.expectLocation != rec.Header().Get("Location") {
+				t.Fatalf("Mismatched redirect. expected=%s, actual=%s", tt.expectLocation, rec.Header().Get("Location"))
+			}
+		})
+	}
+}

--- a/servemux.go
+++ b/servemux.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"net/http"
-	"strings"
 )
 
 // ServeMux is the multiplexer for http requests
@@ -67,14 +66,6 @@ func NewServeMux() *ServeMux {
 
 func (s *ServeMux) getAll(r *http.Request, ex *routeExecution) {
 	path := r.URL.EscapedPath()
-
-	// Check for redirect
-	if path != "/" && strings.HasSuffix(path, "/") {
-		r.URL.Path = strings.TrimRight(path, "/")
-		ex.handler = http.RedirectHandler(r.URL.RequestURI(), http.StatusPermanentRedirect)
-		ex.pattern = r.URL.EscapedPath()
-		return
-	}
 
 	// fill it
 	if route, ok := s.hostRoutes[r.URL.Host]; ok {


### PR DESCRIPTION
Explicitly check for repeated path separators that make a zero-width segment.

Move the redirect logic into the execution generator instead of doing it in the mux itself.